### PR TITLE
fix: 🐛 mac dock click event not handle

### DIFF
--- a/src-tauri/src/core/handle.rs
+++ b/src-tauri/src/core/handle.rs
@@ -84,15 +84,12 @@ impl Handle {
         let title = window_info.title.as_str();
         let url = window_info.url.as_str();
 
-        // Q: 如果有之前的窗口存在, 那就弹出之前的窗口,请补上逻辑
-        // A:
         if let Some(window) = app_handle.get_window(label) {
+			let _ = window.set_always_on_top(true);
             let _ = window.show();
             return;
         }
 
-        // Q: Tauri如何关闭Mac APP的隐藏
-        // A:
         let new_window = tauri::window::WindowBuilder::new(
             app_handle,
             label.to_string(),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -49,7 +49,7 @@ fn init(app: &mut App) -> std::result::Result<(), Box<dyn std::error::Error>> {
         window.close_devtools();
     }
     #[cfg(target_os = "macos")]
-    app.set_activation_policy(tauri::ActivationPolicy::Regular);
+    app.set_activation_policy(tauri::ActivationPolicy::Accessory);
 
     AppConfig::init()?;
     core::handle::Handle::global().init(app.app_handle());


### PR DESCRIPTION
1. hide dock icon
2. make window should always be on top of other windows.

closes: #12 